### PR TITLE
Force Google search results to be in english

### DIFF
--- a/TestCoherence.py
+++ b/TestCoherence.py
@@ -32,7 +32,7 @@ from bs4 import BeautifulSoup
 def test_coherence(noun,verb):
   try:
     # Form our Google query.
-    url = 'https://www.google.com/search?q="' + noun + "+"+ verb + '"'
+    url = 'https://www.google.com/search?q="' + noun + "+"+ verb + '"&hl=en'
 
     # Provide a header so Google will allow us to use their website to search.
     headers = {}


### PR DESCRIPTION
If user's IP address comes from a non-english speaking country, the search results will be in the country's main language, and the parsing will fail. This forces the results page to show in english.
